### PR TITLE
Fixed bug in list_scopes

### DIFF
--- a/bugout/__init__.py
+++ b/bugout/__init__.py
@@ -7,7 +7,7 @@ __description__ = "Python client library for Bugout API"
 
 __email__ = "engineering@bugout.dev"
 __license__ = "MIT"
-__version__ = "0.0.7"
+__version__ = "0.0.8"
 
 __all__ = (
     "__author__",

--- a/bugout/__init__.py
+++ b/bugout/__init__.py
@@ -7,7 +7,7 @@ __description__ = "Python client library for Bugout API"
 
 __email__ = "engineering@bugout.dev"
 __license__ = "MIT"
-__version__ = "0.0.8"
+__version__ = "0.0.7"
 
 __all__ = (
     "__author__",

--- a/bugout/group.py
+++ b/bugout/group.py
@@ -84,7 +84,7 @@ class Group:
             )
 
         data: Dict[str, Any] = {
-            "user_type": user_type,
+            "user_type": user_type.value,
         }
         if username is not None:
             data.update({"username": username})

--- a/bugout/journal.py
+++ b/bugout/journal.py
@@ -5,6 +5,7 @@ from .calls import make_request, InvalidUrlSpec
 from .data import (
     BugoutJournal,
     BugoutJournals,
+    BugoutScope,
     BugoutScopes,
     BugoutJournalScopeSpecs,
     BugoutJournalEntry,
@@ -45,7 +46,8 @@ class Journal:
         result = self._call(
             method=Method.get, path=scopes_path, headers=headers, json=json
         )
-        return BugoutScopes(**result)
+        scopes = [BugoutScope(**item) for item in result]
+        return BugoutScopes(scopes=scopes)
 
     def get_journal_scopes(
         self, token: Union[str, uuid.UUID], journal_id: Union[str, uuid.UUID]

--- a/bugout/journal.py
+++ b/bugout/journal.py
@@ -72,7 +72,7 @@ class Journal:
         journal_scopes_path = f"journals/{journal_id}/scopes"
         json = {
             "holder_type": holder_type.value,
-            "holder_id": holder_id,
+            "holder_id": str(holder_id),
             "permission_list": permission_list,
         }
         headers = {

--- a/bugout/journal.py
+++ b/bugout/journal.py
@@ -71,7 +71,7 @@ class Journal:
     ) -> BugoutJournalScopeSpecs:
         journal_scopes_path = f"journals/{journal_id}/scopes"
         json = {
-            "holder_type": holder_type,
+            "holder_type": holder_type.value,
             "holder_id": holder_id,
             "permission_list": permission_list,
         }

--- a/bugout/journal.py
+++ b/bugout/journal.py
@@ -5,7 +5,6 @@ from .calls import make_request, InvalidUrlSpec
 from .data import (
     BugoutJournal,
     BugoutJournals,
-    BugoutScope,
     BugoutScopes,
     BugoutJournalScopeSpecs,
     BugoutJournalEntry,
@@ -46,8 +45,7 @@ class Journal:
         result = self._call(
             method=Method.get, path=scopes_path, headers=headers, json=json
         )
-        scopes = [BugoutScope(**item) for item in result]
-        return BugoutScopes(scopes=scopes)
+        return BugoutScopes(**result)
 
     def get_journal_scopes(
         self, token: Union[str, uuid.UUID], journal_id: Union[str, uuid.UUID]


### PR DESCRIPTION
Resolves https://github.com/bugout-dev/bugout-python/issues/5

Results is a JSON list of objects that cast into BugoutScope. The
library was trying to unpack this list as a dictionary into
BugoutScopes.

Fixed now with explicit unpacking of a list of `BugoutScope` objects
constructed from the results.