### PR TITLE
Fixed broken journal search

### DIFF
--- a/bugout/__init__.py
+++ b/bugout/__init__.py
@@ -7,7 +7,7 @@ __description__ = "Python client library for Bugout API"
 
 __email__ = "engineering@bugout.dev"
 __license__ = "MIT"
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 
 __all__ = (
     "__author__",

--- a/bugout/app.py
+++ b/bugout/app.py
@@ -192,13 +192,13 @@ class Bugout:
 
     def find_group(
         self,
+        token: Union[str, uuid.UUID],
         group_id: Optional[Union[str, uuid.UUID]] = None,
         name: Optional[str] = None,
-        token: Union[str, uuid.UUID] = None,
         timeout: float = REQUESTS_TIMEOUT,
     ) -> data.BugoutGroup:
         self.user.timeout = timeout
-        return self.group.find_group(group_id=group_id, name=name, token=token)
+        return self.group.find_group(token=token, group_id=group_id, name=name)
 
     def get_user_groups(
         self, token: Union[str, uuid.UUID], timeout: float = REQUESTS_TIMEOUT

--- a/bugout/app.py
+++ b/bugout/app.py
@@ -525,8 +525,11 @@ class Bugout:
         self,
         token: Union[str, uuid.UUID],
         journal_id: Union[str, uuid.UUID],
+        query: str,
+        limit: int = 10,
+        offset: int = 0,
+        content: bool = True,
         timeout: float = REQUESTS_TIMEOUT,
-        **queries: Dict[str, Any],
     ) -> data.BugoutSearchResults:
         self.journal.timeout = timeout
-        return self.journal.search(token=token, journal_id=journal_id, **queries)
+        return self.journal.search(token, journal_id, query, limit, offset, content)

--- a/bugout/data.py
+++ b/bugout/data.py
@@ -153,14 +153,6 @@ class BugoutJournalEntryTags(BaseModel):
     tags: List[str]
 
 
-class BugoutSearchFields(BaseModel):
-    query: str = ""
-    filters: Optional[List[str]] = None
-    limit: int = 10
-    offset: int = 0
-    content: Optional[bool] = True
-
-
 class BugoutSearchResult(BaseModel):
     entry_url: str
     content_url: str

--- a/bugout/group.py
+++ b/bugout/group.py
@@ -49,21 +49,29 @@ class Group:
 
     def find_group(
         self,
+        token: Union[str, uuid.UUID],
         group_id: Optional[Union[str, uuid.UUID]] = None,
         name: Optional[str] = None,
-        token: Union[str, uuid.UUID] = None,
     ) -> BugoutGroup:
         find_group_path = f"group/find"
-        if group_id is not None and name is None:
-            find_group_path += f"?group_id={group_id}"
-        elif group_id is None and name is not None:
-            find_group_path += f"?name={name}"
-        elif group_id is not None and name is not None:
-            find_group_path += f"?group_id={group_id}&name={name}"
+        if group_id is None and name is None:
+            raise GroupInvalidParameters(
+                "In order to find group, at least one of name, or id must be specified"
+            )
+        query_params = {}
+        if group_id is not None:
+            query_params.update({"group_id": group_id})
+        if name is not None:
+            query_params.update({"name": name})
         headers = {
             "Authorization": f"Bearer {token}",
         }
-        result = self._call(method=Method.get, path=find_group_path, headers=headers)
+        result = self._call(
+            method=Method.get,
+            path=find_group_path,
+            params=query_params,
+            headers=headers,
+        )
         return BugoutGroup(**result)
 
     def get_user_groups(self, token: Union[str, uuid.UUID]) -> BugoutUserGroups:

--- a/bugout/user.py
+++ b/bugout/user.py
@@ -222,13 +222,15 @@ class User:
         headers = {
             "Authorization": f"Bearer {token}",
         }
-        if active is not None and token_type is None:
-            get_user_tokens_path += f"?active={active}"
-        elif active is None and token_type is not None:
-            get_user_tokens_path += f"?token_type={token_type.value}"
-        elif active is not None and token_type is not None:
-            get_user_tokens_path += f"?active={active}&token_type={token_type.value}"
+        query_params = {}
+        if active is not None:
+            query_params.update({"active": active})
+        if token_type is not None:
+            query_params.update({"token_type": token_type.value})
         result = self._call(
-            method=Method.get, path=get_user_tokens_path, headers=headers
+            method=Method.get,
+            path=get_user_tokens_path,
+            params=query_params,
+            headers=headers,
         )
         return BugoutUserTokens(**result)

--- a/bugout/user.py
+++ b/bugout/user.py
@@ -224,7 +224,7 @@ class User:
         }
         query_params = {}
         if active is not None:
-            query_params.update({"active": active})
+            query_params.update({"active": str(int(active))})
         if token_type is not None:
             query_params.update({"token_type": token_type.value})
         result = self._call(

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import os
 from importlib.machinery import SourceFileLoader
-from pkg_resources import parse_requirements
 from setuptools import find_packages, setup
 
 MODULE_NAME = "bugout"


### PR DESCRIPTION
Simplified the code by:
1. Using the `requests` `params` keyword argument instead of manually
constructing query string.
2. Accepting query, limit, offset, etc. directly as arguments to the
search method. This way, when you do `help(bugout_client.search)`, you
see immediately what the structure of the input should be.
3. Removing unnecessary Pydantic model for search fields.