### PR TITLE
Renamed entry point of bugout module

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,21 +7,32 @@ Python client library for Bugout API
 export BUGOUT_TIMEOUT_SECONDS=5
 ```
 
+- Example of usage, just fill `token`, `group_id`, `journal_id` and `entry_id` with proper values from your account. Or remove unnecessary variables and API calls.
 ```python
 from bugout.app import Bugout
 
+
 def main():
-    bugout = Bugout(brood_api_url="http://localhost:9001", spire_api_url="http://localhost:9002")
-    
-    user = bugout.get_user(<user token ID>)
+    bugout = Bugout()
+
+    token = ""
+    group_id = ""
+    journal_id = ""
+    entry_id = ""
+
+    user = bugout.get_user(token=token)
     print(f"User name is {user.username}")
-    
-    group = bugout.get_group(<user token ID>, <group ID>)
-    
-    journal = bugout.get_journal(<user token ID>, <journal ID>)
-    entry = bugout.get_entry(<user token ID>, <journal ID>, <entry ID>)
-    
-    search_res = bugout.search(<user token ID>, <journal ID>, query="your query", content=False)
+
+    group = bugout.get_group(token=token, group_id=group_id)
+
+    journal = bugout.get_journal(token=token, journal_id=journal_id)
+    entry = bugout.get_entry(token=token, journal_id=journal.id, entry_id=entry_id)
+
+    search_res = bugout.search(
+        token=token, journal_id=journal.id, query="your query", content=False
+    )
+    print(f"Search results: {search_res}")
+
 
 if __name__ == "__main__":
     main()

--- a/bugout/__init__.py
+++ b/bugout/__init__.py
@@ -7,7 +7,7 @@ __description__ = "Python client library for Bugout API"
 
 __email__ = "engineering@bugout.dev"
 __license__ = "MIT"
-__version__ = "0.1.8"
+__version__ = "0.1.9"
 
 __all__ = (
     "__author__",

--- a/bugout/settings.py
+++ b/bugout/settings.py
@@ -1,7 +1,7 @@
 import os
 
-BUGOUT_BROOD_URL = "https://auth.bugout.dev"
-BUGOUT_SPIRE_URL = "https://spire.bugout.dev"
+BUGOUT_BROOD_URL = os.environ.get("BUGOUT_BROOD_URL", "https://auth.bugout.dev")
+BUGOUT_SPIRE_URL = os.environ.get("BUGOUT_SPIRE_URL", "https://spire.bugout.dev")
 
 REQUESTS_TIMEOUT = 5
 REQUESTS_TIMEOUT_RAW = os.environ.get("BUGOUT_TIMEOUT_SECONDS")

--- a/sample.env
+++ b/sample.env
@@ -1,1 +1,3 @@
+export BUGOUT_BROOD_URL="https://auth.bugout.dev"
+export BUGOUT_SPIRE_URL="https://spire.bugout.dev"
 export BUGOUT_TIMEOUT_SECONDS=5

--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,5 @@ setup(
     zip_safe=False,
     install_requires=["pydantic>=1.6", "requests"],
     extras_require={"dev": ["black", "mypy"]},
-    entry_points={"console_scripts": ["{0} = {0}.__main__:main".format(MODULE_NAME)]},
+    entry_points={"console_scripts": ["{0}-py = {0}.__main__:main".format(MODULE_NAME)]},
 )


### PR DESCRIPTION
In order to avoid problems calling bugout go command line interface, `bugout-python` module entry point will be re-named from `bugout` to `bugout-py`. 
Also added minor changes in `README.md`.