### PR TITLE
Added order argument to journal search method

### DIFF
--- a/bugout/__init__.py
+++ b/bugout/__init__.py
@@ -7,7 +7,7 @@ __description__ = "Python client library for Bugout API"
 
 __email__ = "engineering@bugout.dev"
 __license__ = "MIT"
-__version__ = "0.1.16"
+__version__ = "0.1.17"
 
 __all__ = (
     "__author__",

--- a/bugout/app.py
+++ b/bugout/app.py
@@ -5,7 +5,7 @@ from . import data
 from .calls import ping
 from .group import Group
 from .humbug import Humbug
-from .journal import Journal
+from .journal import Journal, SearchOrder
 from .resource import Resource
 from .user import User
 from .settings import BUGOUT_BROOD_URL, BUGOUT_SPIRE_URL, REQUESTS_TIMEOUT
@@ -685,10 +685,11 @@ class Bugout:
         offset: int = 0,
         content: bool = True,
         timeout: float = REQUESTS_TIMEOUT,
+        order: SearchOrder = SearchOrder.DESCENDING,
     ) -> data.BugoutSearchResults:
         self.journal.timeout = timeout
         return self.journal.search(
-            token, journal_id, query, filters, limit, offset, content
+            token, journal_id, query, filters, limit, offset, content, order=order
         )
 
     # Public

--- a/bugout/journal.py
+++ b/bugout/journal.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Any, List, Optional, Union
 import uuid
 
@@ -20,6 +21,11 @@ from .data import (
 )
 from .exceptions import InvalidUrlSpec
 from .settings import REQUESTS_TIMEOUT
+
+
+class SearchOrder(Enum):
+    ASCENDING = "asc"
+    DESCENDING = "desc"
 
 
 class Journal:
@@ -410,6 +416,7 @@ class Journal:
         limit: int = 10,
         offset: int = 0,
         content: bool = True,
+        order: SearchOrder = SearchOrder.DESCENDING,
     ) -> BugoutSearchResults:
         search_path = f"journals/{journal_id}/search"
         headers = {
@@ -421,6 +428,7 @@ class Journal:
             "limit": limit,
             "offset": offset,
             "content": content,
+            "order": order.value,
         }
         result = self._call(
             method=Method.get, path=search_path, params=query_params, headers=headers


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

Added an `order` argument to the journal search method on the Bugout client.

The values come from the `bugout.journal.SearchOrder` enum.

Bumped library to version to `0.1.17`.

<!-- Please leave a short description of the changes you have made in this pull request. -->
<!-- If applicable, this is the place to discuss alternatives you considered and tradeoffs you made. -->

## How to test these changes?

I tested these changes manually with one of my personal journals.

<!-- Describe how you tested the changes in this pull request. -->
<!-- Describe how someone else could reproduce your tests. -->

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
