### PR TITLE
Adds support for updating tags in the same HTTP request as an entry update

### DIFF
--- a/bugout/__init__.py
+++ b/bugout/__init__.py
@@ -7,7 +7,7 @@ __description__ = "Python client library for Bugout API"
 
 __email__ = "engineering@bugout.dev"
 __license__ = "MIT"
-__version__ = "0.1.18"
+__version__ = "0.1.19"
 
 __all__ = (
     "__author__",

--- a/bugout/app.py
+++ b/bugout/app.py
@@ -5,7 +5,7 @@ from . import data
 from .calls import ping
 from .group import Group
 from .humbug import Humbug
-from .journal import Journal, SearchOrder
+from .journal import Journal, SearchOrder, TagsAction
 from .resource import Resource
 from .user import User
 from .settings import BUGOUT_BROOD_URL, BUGOUT_SPIRE_URL, REQUESTS_TIMEOUT
@@ -595,6 +595,8 @@ class Bugout:
         title: str,
         content: str,
         timeout: float = REQUESTS_TIMEOUT,
+        tags: Optional[List[str]] = None,
+        tags_action: TagsAction = TagsAction.merge,
     ) -> data.BugoutJournalEntryContent:
         self.journal.timeout = timeout
         return self.journal.update_entry_content(
@@ -603,6 +605,8 @@ class Bugout:
             entry_id=entry_id,
             title=title,
             content=content,
+            tags=tags,
+            tags_action=tags_action,
         )
 
     def delete_entry(

--- a/bugout/journal.py
+++ b/bugout/journal.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 import uuid
 
 from .calls import make_request
@@ -26,6 +26,21 @@ from .settings import REQUESTS_TIMEOUT
 class SearchOrder(Enum):
     ASCENDING = "asc"
     DESCENDING = "desc"
+
+
+class TagsAction(Enum):
+    """
+    tags_action query parameter for PUT /{journal_id}/entries/{entry_id} requests.
+    See Spire API implementation of that endpoint for more details:
+    https://github.com/bugout-dev/spire/blob/cc748d45d0aa7e3350105810449ff4c14fa64ec9/spire/journal/api.py#L1249
+
+    Corresponds to EntryUpdateTagActions enum in Spire:
+    https://github.com/bugout-dev/spire/blob/cc748d45d0aa7e3350105810449ff4c14fa64ec9/spire/journal/data.py#L32
+    """
+
+    ignore = "ignore"
+    replace = "replace"
+    merge = "merge"
 
 
 class Journal:
@@ -301,12 +316,18 @@ class Journal:
         entry_id: Union[str, uuid.UUID],
         title: str,
         content: str,
+        tags: Optional[List[str]] = None,
+        tags_action: TagsAction = TagsAction.merge,
     ) -> BugoutJournalEntryContent:
         entry_id_content_path = f"journals/{journal_id}/entries/{entry_id}/content"
+        params: Dict[str, str] = {}
         json = {
             "title": title,
             "content": content,
         }
+        if tags is not None:
+            json["tags"] = tags
+            params["tags_action"] = tags_action.value
         headers = {
             "Authorization": f"Bearer {token}",
         }
@@ -315,6 +336,7 @@ class Journal:
             path=entry_id_content_path,
             headers=headers,
             json=json,
+            params=params,
         )
         return BugoutJournalEntryContent(**result)
 

--- a/bugout/journal.py
+++ b/bugout/journal.py
@@ -321,7 +321,7 @@ class Journal:
     ) -> BugoutJournalEntryContent:
         entry_id_content_path = f"journals/{journal_id}/entries/{entry_id}/content"
         params: Dict[str, str] = {}
-        json = {
+        json: Dict[str, Any] = {
             "title": title,
             "content": content,
         }


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

Fixes the `Bugout.update_entry_content` method to accept `tags` and `tags_action`.

`tags` is an optional list of tags to attach to the entry.

`tags_action` takes values from the new `TagsAction` enum and it specifies whether new tags should be merged into existing tags or should replace them wholesale.

<!-- Please leave a short description of the changes you have made in this pull request. -->
<!-- If applicable, this is the place to discuss alternatives you considered and tradeoffs you made. -->

## How to test these changes?

I tested these changes with the following script:

```python
import os
import unittest

from bugout.app import Bugout
from bugout.journal import TagsAction


class TestUpdateEntry(unittest.TestCase):
    def setUp(self):
        self.access_token = os.environ["BUGOUT_ACCESS_TOKEN"]
        self.journal_id = "<YOUR JOURNAL ID HERE>"
        self.bugout = Bugout()

    def test_changes(self):
        entry = self.bugout.create_entry(
            self.access_token,
            self.journal_id,
            "Test entry",
            "This is a test",
            ["lol", "rofl"],
            "http://example.com",
        )

        self.bugout.update_entry_content(
            self.access_token,
            self.journal_id,
            entry.id,
            "Test entry (updated)",
            "This is a test (modified once)",
            tags=["wtf"],
        )

        updated_entry = self.bugout.get_entry(
            self.access_token, self.journal_id, entry.id
        )
        self.assertEqual(updated_entry.id, entry.id)
        self.assertSetEqual(set(updated_entry.tags), set(entry.tags + ["wtf"]))

        self.bugout.update_entry_content(
            self.access_token,
            self.journal_id,
            entry.id,
            "Test entry (updated twice)",
            "This is a test (modified twice)",
            tags=["bbq"],
            tags_action=TagsAction.replace,
        )
        twice_updated_entry = self.bugout.get_entry(
            self.access_token, self.journal_id, entry.id
        )
        self.assertEqual(twice_updated_entry.id, entry.id)
        self.assertSetEqual(set(twice_updated_entry.tags), {"bbq"})


if __name__ == "__main__":
    unittest.main()
```

To run yourself, replace the `self.journal_id` variable in `setUp` and save the file as `check_update.py` in the root of this repo.

Then run:
```
python check_update.py
```

<!-- Describe how you tested the changes in this pull request. -->
<!-- Describe how someone else could reproduce your tests. -->

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
