### PR TITLE
Properly handle network errors (no response object)

### DIFF
--- a/bugout/calls.py
+++ b/bugout/calls.py
@@ -7,23 +7,26 @@ from .exceptions import BugoutResponseException, BugoutUnexpectedResponse
 
 
 def make_request(method: Method, url: str, **kwargs) -> Any:
-    response_body = None
     try:
-        r = requests.request(method.value, url=url, **kwargs)
-        r.raise_for_status()
-        response_body = r.json()
-    except requests.exceptions.RequestException as e:
-        exception_detail = r.json()
+        response = requests.request(method.value, url=url, **kwargs)
+        response.raise_for_status()
+    except requests.exceptions.RequestException as err:
+        response = err.response
+        if not err.response:
+            # Connection errors, timepouts, etc...
+            raise BugoutResponseException("Network error", detail=str(err))
+        if response.headers.get("Content-Type") == "application/json":
+            exception_detail = response.json()["detail"]
+        else:
+            exception_detail = response.text
         raise BugoutResponseException(
             "An exception occurred at Bugout API side",
-            status_code=r.status_code,
-            detail=exception_detail["detail"]
-            if exception_detail["detail"] is not None
-            else None,
+            status_code=response.status_code,
+            detail=exception_detail,
         )
     except Exception as e:
-        raise BugoutUnexpectedResponse(f"{str(e)}")
-    return response_body
+        raise BugoutUnexpectedResponse({str(e)})
+    return response.json()
 
 
 def ping(url: str) -> Dict[str, Any]:

--- a/bugout/exceptions.py
+++ b/bugout/exceptions.py
@@ -21,7 +21,7 @@ class BugoutResponseException(Exception):
     def __init__(
         self,
         message,
-        status_code: int,
+        status_code: Optional[int] = None,
         detail: Optional[Any] = None,
     ) -> None:
         super().__init__(message)


### PR DESCRIPTION
When a network type error occurs, there is no response object available:


<img width="730" alt="Screen Shot 2022-01-28 at 11 05 12 AM" src="https://user-images.githubusercontent.com/1268088/151580755-12862555-43de-4039-9a3a-0fc4b4406e85.png">

<img width="888" alt="Screen Shot 2022-01-28 at 11 04 43 AM" src="https://user-images.githubusercontent.com/1268088/151580640-10213c94-b36c-46cb-8254-cd72f780d7bb.png">
